### PR TITLE
EA-2224: Enable CORS for pre-flight requests

### DIFF
--- a/common/src/test/java/eu/europeana/oaipmh/util/ResumptionTokenHelperTest.java
+++ b/common/src/test/java/eu/europeana/oaipmh/util/ResumptionTokenHelperTest.java
@@ -3,7 +3,7 @@ package eu.europeana.oaipmh.util;
 import eu.europeana.oaipmh.model.ResumptionToken;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.Base64;

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -92,6 +92,10 @@
                     <artifactId>wstx-asl</artifactId>
                     <groupId>org.codehaus.woodstox</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-all</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- required to load WebMetaInfo in Corelib record

--- a/server/src/main/java/eu/europeana/oaipmh/OaiPmhApplication.java
+++ b/server/src/main/java/eu/europeana/oaipmh/OaiPmhApplication.java
@@ -17,6 +17,9 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
@@ -26,6 +29,8 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * Main application and configuration.
@@ -46,17 +51,19 @@ public class OaiPmhApplication extends SpringBootServletInitializer  {
 
     /**
      * Setup CORS for all requests
-     * @return
      */
     @Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurerAdapter() {
-            @Override
-            public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/oai/**").allowedOrigins("*").maxAge(1000)
-                        .exposedHeaders("Allow, Vary, ETag, Last-Modified");
-            }
-        };
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedHeaders(Collections.singletonList("*"));
+        config.setAllowedOrigins(Collections.singletonList("*"));
+        config.setAllowedMethods(Collections.singletonList("*"));
+        config.setExposedHeaders(Arrays.asList("Allow", "Vary", "ETag", "Last-Modified"));
+        config.setMaxAge(1000L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
     }
 
     /**

--- a/server/src/test/java/eu/europeana/oaipmh/model/metadata/MetadataFormatsTest.java
+++ b/server/src/test/java/eu/europeana/oaipmh/model/metadata/MetadataFormatsTest.java
@@ -5,14 +5,17 @@ import eu.europeana.oaipmh.model.MetadataFormat;
 import eu.europeana.oaipmh.model.MetadataFormatConverter;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class MetadataFormatsTest {
     private static final String METADATA_FORMAT_PREFIX = "format_prefix";
@@ -50,11 +53,11 @@ public class MetadataFormatsTest {
            metadataFormat = new MetadataFormat(METADATA_FORMAT_PREFIX, schemas.get(METADATA_FORMAT_PREFIX), namespaces.get(METADATA_FORMAT_PREFIX), metadataFormatConverter);
            metadataFormats.put(METADATA_FORMAT_PREFIX,metadataFormat);
 
-           Whitebox.setInternalState(testedMetadataFormats, "prefixes", prefixes);
-           Whitebox.setInternalState(testedMetadataFormats, "converters", converters);
-           Whitebox.setInternalState(testedMetadataFormats, "schemas", schemas);
-           Whitebox.setInternalState(testedMetadataFormats, "namespaces", namespaces);
-           Whitebox.setInternalState(testedMetadataFormats, "metadataFormats", metadataFormats);
+        ReflectionTestUtils.setField(testedMetadataFormats, "prefixes", prefixes);
+        ReflectionTestUtils.setField(testedMetadataFormats, "converters", converters);
+        ReflectionTestUtils.setField(testedMetadataFormats, "schemas", schemas);
+        ReflectionTestUtils.setField(testedMetadataFormats, "namespaces", namespaces);
+        ReflectionTestUtils.setField(testedMetadataFormats, "metadataFormats", metadataFormats);
     }
 
     @Test

--- a/server/src/test/java/eu/europeana/oaipmh/service/DBRecordProviderTest.java
+++ b/server/src/test/java/eu/europeana/oaipmh/service/DBRecordProviderTest.java
@@ -17,7 +17,6 @@ import eu.europeana.oaipmh.util.DateConverter;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.springframework.test.util.ReflectionTestUtils;
 import static junit.framework.TestCase.fail;
 
@@ -30,8 +29,6 @@ import java.util.Date;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class DBRecordProviderTest extends BaseApiTestCase {
@@ -58,8 +55,8 @@ public class DBRecordProviderTest extends BaseApiTestCase {
         mongoServer = mock(EdmMongoServer.class);
         recordProvider = spy(DBRecordProvider.class);
 
-        Whitebox.setInternalState(recordProvider, IDENTIFIER_PREFIX_FIELD_NAME, DEFAULT_IDENTIFIER_PREFIX);
-        Whitebox.setInternalState(recordProvider, "mongoServer", mongoServer);
+        ReflectionTestUtils.setField(recordProvider, IDENTIFIER_PREFIX_FIELD_NAME, DEFAULT_IDENTIFIER_PREFIX);
+        ReflectionTestUtils.setField(recordProvider, "mongoServer", mongoServer);
     }
 
     @Test
@@ -96,8 +93,8 @@ public class DBRecordProviderTest extends BaseApiTestCase {
         given(bean.getTimestampCreated()).willReturn(TEST_RECORD_CREATE_DATE);
         given(bean.getEuropeanaCollectionName()).willReturn(TEST_RECORD_SETS);
 
-        Whitebox.setInternalState(recordProvider, "threadsCount", 1);
-        Whitebox.setInternalState(recordProvider, "maxThreadsCount", 20);
+        ReflectionTestUtils.setField(recordProvider, "threadsCount", 1);
+        ReflectionTestUtils.setField(recordProvider, "maxThreadsCount", 20);
         ReflectionTestUtils.invokeMethod(recordProvider, "initThreadPool");
     }
 


### PR DESCRIPTION
Also: 
- fixes incorrect Mockito version being found in classpath.
- replaces invocations of Whitebox.setInternalState, which has been removed from Mockito