### PR TITLE
Changes for liveness and readiness

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,14 +15,14 @@ spec:
             httpGet:
               port: 8080
               path: /actuator/info
-            initialDelaySeconds: 100
-            periodSeconds: 60
+            initialDelaySeconds: 40
+            periodSeconds: 20
           readinessProbe:
             httpGet:
               port: 8080
               path: /actuator/info
-            initialDelaySeconds: 80
-            periodSeconds: 30
+            initialDelaySeconds: 40
+            periodSeconds: 20
           volumeMounts:
             - name: secret
               mountPath: "/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/oai-pmh.user.properties"

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -7,16 +7,23 @@ spring:
     name: OAI-PMH Server
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: info, health
+
+  info:
+    env:
+      enabled: true
+
   endpoint:
     health:
       probes:
         enabled: true
+      show-details: always
+
   health:
-    livenessstate:
+    livenessState:
       enabled: true
-    readinessstate:
+    readinessState:
       enabled: true
-  endpoints:
-    web:
-      exposure:
-        include: info


### PR DESCRIPTION
New values are based on analysis of max-min application startup time from prod /acceptance/test environment
observed (max-min) 33.058- 28.359 seconds for OAi-PMH